### PR TITLE
Add equals, hashcode, toString for testability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,13 @@
       <groupId>io.springfox</groupId>
       <artifactId>springfox-swagger2</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.jvnet.jaxb2_commons</groupId>
+      <artifactId>jaxb2-basics</artifactId>
+      <version>1.11.1</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -83,6 +90,9 @@
                 <arg>-Xvalue-constructor</arg>
                 <arg>-Xfluent-builder</arg>
                 <arg>-generateTools=n</arg>
+                <arg>-XsimpleEquals</arg>
+                <arg>-XsimpleHashCode</arg>
+                <arg>-XtoString</arg>
               </args>
               <plugins>
                 <plugin>
@@ -94,6 +104,11 @@
                   <groupId>org.jvnet.jaxb2_commons</groupId>
                   <artifactId>jaxb2-value-constructor</artifactId>
                   <version>3.0</version>
+                </plugin>
+                <plugin>
+                  <groupId>org.jvnet.jaxb2_commons</groupId>
+                  <artifactId>jaxb2-basics</artifactId>
+                  <version>1.11.1</version>
                 </plugin>
               </plugins>
             </configuration>
@@ -121,6 +136,9 @@
                 <arg>-Xvalue-constructor</arg>
                 <arg>-Xfluent-builder</arg>
                 <arg>-generateTools=n</arg>
+                <arg>-XsimpleEquals</arg>
+                <arg>-XsimpleHashCode</arg>
+                <arg>-XtoString</arg>
               </args>
               <plugins>
                 <plugin>
@@ -132,6 +150,11 @@
                   <groupId>org.jvnet.jaxb2_commons</groupId>
                   <artifactId>jaxb2-value-constructor</artifactId>
                   <version>3.0</version>
+                </plugin>
+                <plugin>
+                  <groupId>org.jvnet.jaxb2_commons</groupId>
+                  <artifactId>jaxb2-basics</artifactId>
+                  <version>1.11.1</version>
                 </plugin>
               </plugins>
             </configuration>


### PR DESCRIPTION
# Motivation and Context
To test equality and get good testing output you need to have the
equals, hashcode and toString method generated on the java source.

# What has changed

Using the org.jvnet.jaxb2_commons.jaxb2-basics plugin to generate the
methods

# How to test?
1. Run `mvn install`
1. Check that the equals, hashcode and toString methods have been generated in the ActionRequest.class, ActionAddress.class, ActionContact.class compiled classes using intellij

# Links
http://rastkososkic.blogspot.com/2014/10/generating-tostring-method-in-jax-b.html
https://trello.com/c/xbFrDWWf/100-dev-task-5-int-notify-respondent-of-invitation-to-a-survey-5