### PR TITLE
Add action plan selectors

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionPlanDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionPlanDTO.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import javax.validation.constraints.NotNull;
 import java.util.Date;
 import java.util.UUID;
+import java.util.HashMap;
 
 /**
  * Domain model object for representation.
@@ -27,4 +28,6 @@ public class ActionPlanDTO {
   private String createdBy;
 
   private Date lastRunDateTime;
+
+  private HashMap<String, String> selectors;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionPlanDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionPlanDTO.java
@@ -28,6 +28,4 @@ public class ActionPlanDTO {
   private String createdBy;
 
   private Date lastRunDateTime;
-
-  private HashMap<String, String> selectors;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionPlanDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionPlanDTO.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import javax.validation.constraints.NotNull;
 import java.util.Date;
 import java.util.UUID;
-import java.util.HashMap;
 
 /**
  * Domain model object for representation.

--- a/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionPlanPostRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionPlanPostRequestDTO.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.util.HashMap;
 
 /**
  * Domain model object for representation.
@@ -28,5 +29,7 @@ public class ActionPlanPostRequestDTO {
     @NotNull
     @Size(max = 20)
     private String createdBy;
+
+    private HashMap<String, String> selectors;
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionPlanPutRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionPlanPutRequestDTO.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.Date;
+import java.util.HashMap;
 
 /**
  * Domain model object for representation.
@@ -18,4 +19,6 @@ public class ActionPlanPutRequestDTO {
   private String description;
 
   private Date lastRunDateTime;
+
+  private HashMap<String, String> selectors;
 }


### PR DESCRIPTION
# Motivation and Context
Selectors can now be passed as part of POST and PUT requests to actionplan endpoints

# What has changed
Added Hashmap selectors field to POST and PUT requests

# How to test?
Test in conjunction with [associated PR in action service](https://github.com/ONSdigital/rm-action-service/pull/56)

# Links
[Trello](https://trello.com/c/piwT43rb/9-create-actionplan-selectors-action)
[action-service PR](https://github.com/ONSdigital/rm-action-service/pull/56)
