### PR TITLE
Add Situation value object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,28 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <configuration>
+          <properties>
+            <property>
+              <name>junit</name>
+              <value>false</value>
+            </property>
+          </properties>
+          <threadCount>1</threadCount>
+        </configuration>
+        <!-- REQUIRED for unit tests to run -->
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit47</artifactId>
+            <version>${surefire.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>
           <checkModificationExcludes>

--- a/src/main/java/uk/gov/ons/ctp/response/action/factory/ActionFeedbackFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/factory/ActionFeedbackFactory.java
@@ -1,0 +1,11 @@
+package uk.gov.ons.ctp.response.action.factory;
+
+import uk.gov.ons.ctp.response.action.message.feedback.ActionFeedback;
+import uk.gov.ons.ctp.response.action.message.feedback.Outcome;
+import uk.gov.ons.ctp.response.action.representation.Situation;
+
+public class ActionFeedbackFactory {
+  public static ActionFeedback create(String actionId, Situation situation, Outcome outcome) {
+    return new ActionFeedback(actionId, situation.toString(), outcome);
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/action/representation/Situation.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/representation/Situation.java
@@ -1,0 +1,21 @@
+package uk.gov.ons.ctp.response.action.representation;
+
+import uk.gov.ons.ctp.response.action.representation.exception.InvalidSituationException;
+
+public class Situation {
+  public static final int MAXIMUM_LENGTH = 100;
+  private final String situation;
+
+  public Situation(String situation) throws InvalidSituationException {
+    if (situation.length() > MAXIMUM_LENGTH) {
+      throw InvalidSituationException.tooLong(situation);
+    }
+
+    this.situation = situation;
+  }
+
+  @Override
+  public String toString() {
+    return situation;
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/action/representation/Situation.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/representation/Situation.java
@@ -6,7 +6,7 @@ public class Situation {
   public static final int MAXIMUM_LENGTH = 100;
   private final String situation;
 
-  public Situation(String situation) throws InvalidSituationException {
+  public Situation(String situation) {
     if (situation.length() > MAXIMUM_LENGTH) {
       throw InvalidSituationException.tooLong(situation);
     }

--- a/src/main/java/uk/gov/ons/ctp/response/action/representation/exception/InvalidSituationException.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/representation/exception/InvalidSituationException.java
@@ -1,15 +1,14 @@
 package uk.gov.ons.ctp.response.action.representation.exception;
 
-import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.action.representation.Situation;
 
-public class InvalidSituationException extends CTPException {
+public class InvalidSituationException extends RuntimeException {
 
   private static final String TOO_LONG_MESSAGE =
       "Situation can have a maximum length of %d; got \"%s\"";
 
-  private InvalidSituationException(String message) {
-    super(Fault.VALIDATION_FAILED, message);
+  public InvalidSituationException(String message) {
+    super(message);
   }
 
   public static InvalidSituationException tooLong(String situation) {

--- a/src/main/java/uk/gov/ons/ctp/response/action/representation/exception/InvalidSituationException.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/representation/exception/InvalidSituationException.java
@@ -7,7 +7,7 @@ public class InvalidSituationException extends RuntimeException {
   private static final String TOO_LONG_MESSAGE =
       "Situation can have a maximum length of %d; got \"%s\"";
 
-  public InvalidSituationException(String message) {
+  private InvalidSituationException(String message) {
     super(message);
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/representation/exception/InvalidSituationException.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/representation/exception/InvalidSituationException.java
@@ -1,0 +1,19 @@
+package uk.gov.ons.ctp.response.action.representation.exception;
+
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.action.representation.Situation;
+
+public class InvalidSituationException extends CTPException {
+
+  private static final String TOO_LONG_MESSAGE =
+      "Situation can have a maximum length of %d; got \"%s\"";
+
+  private InvalidSituationException(String message) {
+    super(Fault.VALIDATION_FAILED, message);
+  }
+
+  public static InvalidSituationException tooLong(String situation) {
+    return new InvalidSituationException(
+        String.format(TOO_LONG_MESSAGE, Situation.MAXIMUM_LENGTH, situation));
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/action/factory/ActionFeedbackFactoryTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/factory/ActionFeedbackFactoryTest.java
@@ -1,0 +1,28 @@
+package uk.gov.ons.ctp.response.action.factory;
+
+import org.junit.Test;
+import uk.gov.ons.ctp.response.action.message.feedback.ActionFeedback;
+import uk.gov.ons.ctp.response.action.message.feedback.Outcome;
+import uk.gov.ons.ctp.response.action.representation.Situation;
+import uk.gov.ons.ctp.response.action.representation.exception.InvalidSituationException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ActionFeedbackFactoryTest {
+
+  public static final String ACTION_ID = "08073f47-1d8d-44cf-b035-31c398ec46bf";
+  public static final String SITUATION_STRING = "NotifyGateway";
+  public static final Outcome OUTCOME = Outcome.CANCELLATION_ACCEPTED;
+
+  @Test
+  public void
+  testItCreatesAnActionFeedbackInstance() throws InvalidSituationException {
+    final Situation situation = new Situation(SITUATION_STRING);
+
+    ActionFeedback actionFeedback = ActionFeedbackFactory.create(ACTION_ID, situation, OUTCOME);
+
+    assertEquals(ACTION_ID, actionFeedback.getActionId());
+    assertEquals(SITUATION_STRING, actionFeedback.getSituation());
+    assertEquals(Outcome.CANCELLATION_ACCEPTED, actionFeedback.getOutcome());
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/action/factory/ActionFeedbackFactoryTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/factory/ActionFeedbackFactoryTest.java
@@ -9,9 +9,9 @@ import static org.junit.Assert.assertEquals;
 
 public class ActionFeedbackFactoryTest {
 
-  public static final String ACTION_ID = "08073f47-1d8d-44cf-b035-31c398ec46bf";
-  public static final String SITUATION_STRING = "NotifyGateway";
-  public static final Outcome OUTCOME = Outcome.CANCELLATION_ACCEPTED;
+  private static final String ACTION_ID = "08073f47-1d8d-44cf-b035-31c398ec46bf";
+  private static final String SITUATION_STRING = "NotifyGateway";
+  private static final Outcome OUTCOME = Outcome.CANCELLATION_ACCEPTED;
 
   @Test
   public void testItCreatesAnActionFeedbackInstance() {

--- a/src/test/java/uk/gov/ons/ctp/response/action/factory/ActionFeedbackFactoryTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/factory/ActionFeedbackFactoryTest.java
@@ -4,7 +4,6 @@ import org.junit.Test;
 import uk.gov.ons.ctp.response.action.message.feedback.ActionFeedback;
 import uk.gov.ons.ctp.response.action.message.feedback.Outcome;
 import uk.gov.ons.ctp.response.action.representation.Situation;
-import uk.gov.ons.ctp.response.action.representation.exception.InvalidSituationException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -15,8 +14,7 @@ public class ActionFeedbackFactoryTest {
   public static final Outcome OUTCOME = Outcome.CANCELLATION_ACCEPTED;
 
   @Test
-  public void
-  testItCreatesAnActionFeedbackInstance() throws InvalidSituationException {
+  public void testItCreatesAnActionFeedbackInstance() {
     final Situation situation = new Situation(SITUATION_STRING);
 
     ActionFeedback actionFeedback = ActionFeedbackFactory.create(ACTION_ID, situation, OUTCOME);

--- a/src/test/java/uk/gov/ons/ctp/response/action/representation/SituationTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/representation/SituationTest.java
@@ -11,9 +11,9 @@ import static uk.gov.ons.ctp.response.action.representation.Situation.MAXIMUM_LE
 
 public class SituationTest {
 
-  public static final String VALID = "Notify Sms Not Sent";
-  public static final String TOO_LONG = StringUtils.repeat("a", MAXIMUM_LENGTH + 1);
-  public static final String MAX_LENGTH = StringUtils.repeat("x", MAXIMUM_LENGTH);
+  private static final String VALID = "Notify Sms Not Sent";
+  private static final String TOO_LONG = StringUtils.repeat("a", MAXIMUM_LENGTH + 1);
+  private static final String MAX_LENGTH = StringUtils.repeat("x", MAXIMUM_LENGTH);
 
   @Rule public ExpectedException expectedEx = ExpectedException.none();
 

--- a/src/test/java/uk/gov/ons/ctp/response/action/representation/SituationTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/representation/SituationTest.java
@@ -1,13 +1,13 @@
 package uk.gov.ons.ctp.response.action.representation;
 
-import static org.junit.Assert.assertEquals;
-import static uk.gov.ons.ctp.response.action.representation.Situation.MAXIMUM_LENGTH;
-
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.ons.ctp.response.action.representation.exception.InvalidSituationException;
+
+import static org.junit.Assert.assertEquals;
+import static uk.gov.ons.ctp.response.action.representation.Situation.MAXIMUM_LENGTH;
 
 public class SituationTest {
 
@@ -18,14 +18,14 @@ public class SituationTest {
   @Rule public ExpectedException expectedEx = ExpectedException.none();
 
   @Test
-  public void testToStringReturnsTheValue() throws InvalidSituationException {
+  public void testToStringReturnsTheValue() {
     Situation situation = new Situation(VALID);
 
     assertEquals(situation.toString(), VALID);
   }
 
   @Test
-  public void testItThrowsAnExceptionIfSituationIsTooLong() throws InvalidSituationException {
+  public void testItThrowsAnExceptionIfSituationIsTooLong() {
     expectedEx.expect(InvalidSituationException.class);
     expectedEx.expectMessage(InvalidSituationException.tooLong(TOO_LONG).getMessage());
 
@@ -33,8 +33,7 @@ public class SituationTest {
   }
 
   @Test
-  public void testItDoesNotThrowAnExceptionIfTheSituationIsTheMaximumLength()
-      throws InvalidSituationException {
+  public void testItDoesNotThrowAnExceptionIfTheSituationIsTheMaximumLength() {
     new Situation(MAX_LENGTH);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/action/representation/SituationTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/representation/SituationTest.java
@@ -1,0 +1,40 @@
+package uk.gov.ons.ctp.response.action.representation;
+
+import static org.junit.Assert.assertEquals;
+import static uk.gov.ons.ctp.response.action.representation.Situation.MAXIMUM_LENGTH;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import uk.gov.ons.ctp.response.action.representation.exception.InvalidSituationException;
+
+public class SituationTest {
+
+  public static final String VALID = "Notify Sms Not Sent";
+  public static final String TOO_LONG = StringUtils.repeat("a", MAXIMUM_LENGTH + 1);
+  public static final String MAX_LENGTH = StringUtils.repeat("x", MAXIMUM_LENGTH);
+
+  @Rule public ExpectedException expectedEx = ExpectedException.none();
+
+  @Test
+  public void testToStringReturnsTheValue() throws InvalidSituationException {
+    Situation situation = new Situation(VALID);
+
+    assertEquals(situation.toString(), VALID);
+  }
+
+  @Test
+  public void testItThrowsAnExceptionIfSituationIsTooLong() throws InvalidSituationException {
+    expectedEx.expect(InvalidSituationException.class);
+    expectedEx.expectMessage(InvalidSituationException.tooLong(TOO_LONG).getMessage());
+
+    new Situation(TOO_LONG);
+  }
+
+  @Test
+  public void testItDoesNotThrowAnExceptionIfTheSituationIsTheMaximumLength()
+      throws InvalidSituationException {
+    new Situation(MAX_LENGTH);
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/action/representation/exception/InvalidSituationExceptionTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/representation/exception/InvalidSituationExceptionTest.java
@@ -1,0 +1,28 @@
+package uk.gov.ons.ctp.response.action.representation.exception;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import uk.gov.ons.ctp.common.error.CTPException;
+
+public class InvalidSituationExceptionTest {
+  @Test
+  public void testInvalidSituationExceptionIsACTPException() {
+    assertTrue(InvalidSituationException.tooLong("long message") instanceof CTPException);
+  }
+
+  @Test
+  public void testTooLongMessageIsDescriptive() {
+    final InvalidSituationException exception = InvalidSituationException.tooLong("long message");
+
+    assertEquals(
+        exception.getMessage(), "Situation can have a maximum length of 100; got \"long message\"");
+  }
+
+  @Test
+  public void testInvalidExceptionIsAValidFailure() {
+    CTPException exception = InvalidSituationException.tooLong("long message");
+    assertEquals(exception.getFault(), CTPException.Fault.VALIDATION_FAILED);
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/action/representation/exception/InvalidSituationExceptionTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/representation/exception/InvalidSituationExceptionTest.java
@@ -1,28 +1,15 @@
 package uk.gov.ons.ctp.response.action.representation.exception;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Test;
-import uk.gov.ons.ctp.common.error.CTPException;
+
+import static org.junit.Assert.assertEquals;
 
 public class InvalidSituationExceptionTest {
-  @Test
-  public void testInvalidSituationExceptionIsACTPException() {
-    assertTrue(InvalidSituationException.tooLong("long message") instanceof CTPException);
-  }
-
   @Test
   public void testTooLongMessageIsDescriptive() {
     final InvalidSituationException exception = InvalidSituationException.tooLong("long message");
 
     assertEquals(
         exception.getMessage(), "Situation can have a maximum length of 100; got \"long message\"");
-  }
-
-  @Test
-  public void testInvalidExceptionIsAValidFailure() {
-    CTPException exception = InvalidSituationException.tooLong("long message");
-    assertEquals(exception.getFault(), CTPException.Fault.VALIDATION_FAILED);
   }
 }


### PR DESCRIPTION
# Motivation and Context
There is repeated logic throughout the services which verifies
the validity of the situation string for `ActionFeedback`
(limited to 100 chars). This class moves that validation
to a single place but `ActionFeedback` still expects a string.
For now the `toString()` method can be used but it would be
better if `ActionFeedback` accepted a proper `Situation` type
in the future (not sure if this is possible with the jaxb
generated class).

# What has changed
Add `Situation` value object.

# How to test?
This only adds to the API so just run the unit tests.

# Links
Used by https://github.com/ONSdigital/rm-notify-gateway/pull/32