### PR TITLE
Remove size validation on Enum

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionRulePostRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionRulePostRequestDTO.java
@@ -19,9 +19,7 @@ public class ActionRulePostRequestDTO {
 
   @NotNull private UUID actionPlanId;
 
-  @NotNull
-  @Size(max = 100)
-  private ActionType actionTypeName;
+  @NotNull private ActionType actionTypeName;
 
   @NotNull
   @Size(max = 100)


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Found a bug when using the api with action service. Currently there is a @size annotation on an enum type which is wrong.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
@size annotation on an enum type is now removed.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Can test with action service https://github.com/ONSdigital/rm-action-service/pull/72

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
