### PR TITLE
Rename ActionType enum

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionRuleDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionRuleDTO.java
@@ -18,5 +18,5 @@ public class ActionRuleDTO {
   private String description;
   private OffsetDateTime triggerDateTime;
   private Integer priority;
-  private ActionType actionTypeName;
+  private ActionTypes actionTypeName;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionRulePostRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionRulePostRequestDTO.java
@@ -19,7 +19,7 @@ public class ActionRulePostRequestDTO {
 
   @NotNull private UUID actionPlanId;
 
-  @NotNull private ActionType actionTypeName;
+  @NotNull private ActionTypes actionTypeName;
 
   @NotNull
   @Size(max = 100)

--- a/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionTypes.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/representation/ActionTypes.java
@@ -1,6 +1,6 @@
 package uk.gov.ons.ctp.response.action.representation;
 
-public enum ActionType {
+public enum ActionTypes {
   BSNOT("BSNOT"),
   BSREM("BSREM"),
   BSSNE("BSSNE"),
@@ -15,7 +15,7 @@ public enum ActionType {
 
   private String name;
 
-  ActionType(String name) {
+  ActionTypes(String name) {
     this.name = name;
   }
 


### PR DESCRIPTION
# Motivation and Context
There are two classes called ActionType currently; one of them is an enum and the other is an entity class which also contains the ActionType enum. Currently in order to differentiate the two classes we use qualifiers detailing which ActionType symbol it is. Renaming the enum to ActionTypes resolves this confusion.

# What has changed
ActionType enum renamed to ActionTypes

# How to test?
Ensure project builds successfully. Action service will be taken care of in a separate PR.
