### PR TITLE
Fix address used in action request

### DIFF
--- a/src/main/resources/actionsvc/xsd/actionInstruction.xsd
+++ b/src/main/resources/actionsvc/xsd/actionInstruction.xsd
@@ -36,8 +36,6 @@
     <!-- a complex type for addresses - no statistical geography info -->
     <xs:complexType name="ActionAddress">
         <xs:sequence>
-            <xs:element name="sampleUnitRef" type="xs:string"
-                        minOccurs="1" maxOccurs="1"/>
             <xs:element name="type" type="xs:string" minOccurs="0"
                         maxOccurs="1"/>
             <xs:element name="estabType" type="xs:string" minOccurs="0"
@@ -92,6 +90,7 @@
                     <xs:element name="surveyName" type="xs:string" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="surveyRef" type="xs:string" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="returnByDate" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="sampleUnitRef" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>

--- a/src/main/resources/actionsvc/xsd/actionInstruction.xsd
+++ b/src/main/resources/actionsvc/xsd/actionInstruction.xsd
@@ -74,7 +74,7 @@
                     <xs:element name="actionType" type="xs:string" minOccurs="1" maxOccurs="1"/>
                     <xs:element name="questionSet" type="xs:string" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="contact" type="ActionContact" minOccurs="0" maxOccurs="1"/>
-                    <xs:element name="address" type="ActionAddress" minOccurs="1"/>
+                    <xs:element name="address" type="ActionAddress" minOccurs="0"/>
                     <xs:element name="legalBasis" type="xs:string" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="region" type="xs:string" minOccurs="0" maxOccurs="1"/>
                     <xs:element name="respondentStatus" type="xs:string" minOccurs="0" maxOccurs="1"/>
@@ -146,7 +146,7 @@
     <xs:complexType name="Action">
         <xs:sequence>
             <xs:element name="actionId" type="xs:string"/>
-            <xs:element name="responseRequired" type="xs:boolean"></xs:element>
+            <xs:element name="responseRequired" type="xs:boolean"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/src/main/resources/actionsvc/xsd/actionInstruction.xsd.xml
+++ b/src/main/resources/actionsvc/xsd/actionInstruction.xsd.xml
@@ -25,6 +25,7 @@
       <!--Optional:-->
       <tradingStyle>string</tradingStyle>
     </contact>
+    <!--Optional:-->
     <address>
       <!--Optional:-->
       <type>string</type>

--- a/src/main/resources/actionsvc/xsd/actionInstruction.xsd.xml
+++ b/src/main/resources/actionsvc/xsd/actionInstruction.xsd.xml
@@ -26,7 +26,6 @@
       <tradingStyle>string</tradingStyle>
     </contact>
     <address>
-      <sampleUnitRef>string</sampleUnitRef>
       <!--Optional:-->
       <type>string</type>
       <!--Optional:-->
@@ -71,6 +70,7 @@
     <surveyRef>string</surveyRef>
     <!--Optional:-->
     <returnByDate>string</returnByDate>
+    <sampleUnitRef>string</sampleUnitRef>
   </actionRequest>
   <actionUpdate>
     <actionId>string</actionId>


### PR DESCRIPTION
## Do not merge yet: Need to ensure all related PRs are tested in Pre-prod and discussed with FWM Team first

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We are not using the most recent address when a print file is being generated for social reminders. We therefore need to ensure the most recent address is used in action requests, and also to allow business action requests to still process correctly as a result of these changes.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
This PR updates the Action instruction to allow an optional address (instead of mandatory) and moves the sampleUnitRef into the action request (moved from address).

Related PRs:
[rm-action-service](https://github.com/ONSdigital/rm-action-service/pull/116)
[rm-actionexporter-service](https://github.com/ONSdigital/rm-actionexporter-service/pull/66)

* Make `address` optional in ActionRequest
* Move `sampleUnitRef` from ActionAddress into ActionRequest

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/BNWyG8P1/260-bug200-addresses-are-not-being-updated-when-a-new-one-for-that-ru-is-being-updated-20)